### PR TITLE
Moving ::Lisp cons method into its own namespaced class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'pry'
+
 # Specify your gem's dependencies in ruby_ukanren.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'pry'
-
 # Specify your gem's dependencies in ruby_ukanren.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following example demonstrates how MicroKanren can be used from the console:
 > include MicroKanren::MiniKanrenWrappers
 
 > res = call_fresh(-> (q) { eq(q, 5) }).call(empty_state)
-> puts lprint(res)
+> lprint(res)
 (((([0] . 5)) . 1))
 ```
 

--- a/lib/micro_kanren.rb
+++ b/lib/micro_kanren.rb
@@ -1,4 +1,5 @@
 require "micro_kanren/version"
+require "micro_kanren/cons"
 require "micro_kanren/lisp"
 require "micro_kanren/core"
 require "micro_kanren/var"

--- a/lib/micro_kanren/cons.rb
+++ b/lib/micro_kanren/cons.rb
@@ -5,14 +5,36 @@ module MicroKanren
     # Returns a Cons cell (read: instance) that is also marked as such for later identification.
     def initialize(car, cdr)
       @car, @cdr = car, cdr
-      self.tap do |func|
-        func.instance_eval{ def ccel? ; true ; end }
+    end
+
+    # Converts Lisp AST to a String. Algorithm is a recursive implementation of
+    # http://www.mat.uc.pt/~pedro/cientificos/funcional/lisp/gcl_22.html#SEC1238.
+    def to_s(cons_in_cdr = false)
+      str = cons_in_cdr ? '' : '('
+      cons?(self.car) ? str += self.car.to_s : str += atom_string(self.car)
+
+      if cons?(self.cdr)
+        str += ' ' + self.cdr.to_s(true)
+      else
+        str += ' . ' + atom_string(self.cdr) unless self.cdr.nil?
+      end
+
+      cons_in_cdr ? str : str << ')'
+    end
+
+    private
+
+    def atom_string(node)
+      case node
+      when NilClass, Array, String
+        node.inspect
+      else
+        node.to_s
       end
     end
 
-    def to_s
-      # eventually this will be a replacement for lprint from ::Lisp
+    def cons?(d)
+      d.is_a?(MicroKanren::Cons)
     end
-
   end
 end

--- a/lib/micro_kanren/cons.rb
+++ b/lib/micro_kanren/cons.rb
@@ -1,0 +1,18 @@
+module MicroKanren
+  class Cons
+    attr_reader :car, :cdr
+
+    # Returns a Cons cell (read: instance) that is also marked as such for later identification.
+    def initialize(car, cdr)
+      @car, @cdr = car, cdr
+      self.tap do |func|
+        func.instance_eval{ def ccel? ; true ; end }
+      end
+    end
+
+    def to_s
+      # eventually this will be a replacement for lprint from ::Lisp
+    end
+
+  end
+end

--- a/lib/micro_kanren/lisp.rb
+++ b/lib/micro_kanren/lisp.rb
@@ -9,8 +9,9 @@ module MicroKanren
     def cdr(z)    ; z.cdr    ; end
 
     def cons?(d)
-      d.respond_to?(:ccel?) && d.ccel?
+      d.is_a?(MicroKanren::Cons)
     end
+    # Why did you alias `:cons?` like this?
     alias :pair? :cons?
 
     def map(func, list)
@@ -48,41 +49,11 @@ module MicroKanren
       end
     end
 
-    # Converts Lisp AST to a String. Algorithm is a recursive implementation of
-    # http://www.mat.uc.pt/~pedro/cientificos/funcional/lisp/gcl_22.html#SEC1238.
-    def lprint(node, cons_in_cdr = false)
-      if cons?(node)
-        str = cons_in_cdr ? '' : '('
-        str += lprint(car(node))
-
-        if cons?(cdr(node))
-          str += ' ' + lprint(cdr(node), true)
-        else
-          str += ' . ' + lprint(cdr(node)) unless cdr(node).nil?
-        end
-
-        cons_in_cdr ? str : str << ')'
-      else
-        atom_string(node)
-      end
-    end
-
     def lists_equal?(a, b)
       if cons?(a) && cons?(b)
         lists_equal?(car(a), car(b)) && lists_equal?(cdr(a), cdr(b))
       else
         a == b
-      end
-    end
-
-    private
-
-    def atom_string(node)
-      case node
-      when NilClass, Array, String
-        node.inspect
-      else
-        node.to_s
       end
     end
 

--- a/lib/micro_kanren/lisp.rb
+++ b/lib/micro_kanren/lisp.rb
@@ -1,15 +1,12 @@
 module MicroKanren
   module Lisp
 
-    # Returns a Cons cell that is also marked as such for later identification.
-    def cons(x, y)
-      -> (m) { m.call(x, y) }.tap do |func|
-        func.instance_eval{ def ccel? ; true ; end }
-      end
+    def cons(x,y)
+      Cons.new(x,y)
     end
 
-    def car(z)     ; z.call(-> (p, q) { p }) ; end
-    def cdr(z)     ; z.call(-> (p, q) { q }) ; end
+    def car(z)    ; z.car    ; end
+    def cdr(z)    ; z.cdr    ; end
 
     def cons?(d)
       d.respond_to?(:ccel?) && d.ccel?

--- a/spec/micro_kanren/cons_spec.rb
+++ b/spec/micro_kanren/cons_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe MicroKanren::Cons do
+  include MicroKanren::Lisp
+
+  describe "#initialize" do
+    it "takes two arguments for car and cdr" do
+      MicroKanren::Cons.new(1, 2).must_be_instance_of MicroKanren::Cons
+      proc {MicroKanren::Cons.new(1)}.must_raise ArgumentError
+    end
+  end
+
+  describe "#to_s" do
+    it "prints an expression correctly" do
+      c = cons(1, cons(2, cons(cons(3, cons(4, nil)), cons(5, nil))))
+      c.to_s.must_equal "(1 2 (3 4) 5)"
+      d = cons(cons(2, 3), 1)
+      d.to_s.must_equal "((2 . 3) . 1)"
+      e = cons(1, nil)
+      e.to_s.must_equal "(1)"
+      # Is this an illogical list to be testing?
+      f = cons(nil, 1)
+      f.to_s.must_equal "(nil . 1)  "
+    end
+
+    it "prints a cons cell representation of a simple cell" do
+      cons('a', 'b').to_s.must_equal '("a" . "b")'
+    end
+
+    it "represents Integers and Floats" do
+      cons(1, 2).to_s.must_equal '(1 . 2)'
+    end
+
+    it "prints a nested expression" do
+      cons('a', cons('b', 'c')).to_s.must_equal '("a" "b" . "c")'
+    end
+
+    it "represents Arrays (in scheme, vectors) correctly in printed form" do
+      cons('a', []).to_s.must_equal '("a" . [])'
+    end
+
+    it "represents nil elements (in scheme, '())" do
+      cons('a', nil).to_s.must_equal '("a")'
+    end
+  end
+end

--- a/spec/micro_kanren/core_spec.rb
+++ b/spec/micro_kanren/core_spec.rb
@@ -14,7 +14,7 @@ describe MicroKanren::Core do
 
   it "second-set t1" do
     res = car(call_fresh(-> (q) { eq(q, 5) }).call(empty_state))
-    lprint(res).must_equal '((([0] . 5)) . 1)'
+    res.to_s.must_equal '((([0] . 5)) . 1)'
   end
 
   it "second-set t2" do
@@ -24,17 +24,17 @@ describe MicroKanren::Core do
 
   it "second-set t3" do
     res = car(a_and_b.call(empty_state))
-    lprint(res).must_equal '((([1] . 5) ([0] . 7)) . 2)'
+    res.to_s.must_equal '((([1] . 5) ([0] . 7)) . 2)'
   end
 
   it "second set t3, take" do
     res = take(1, (a_and_b.call(empty_state)))
-    lprint(res).must_equal '(((([1] . 5) ([0] . 7)) . 2))'
+    res.to_s.must_equal '(((([1] . 5) ([0] . 7)) . 2))'
   end
 
   it "second set t4" do
     res = car(cdr(a_and_b.call(empty_state)))
-    lprint(res).must_equal '((([1] . 6) ([0] . 7)) . 2)'
+    res.to_s.must_equal '((([1] . 6) ([0] . 7)) . 2)'
   end
 
   it "second set t5" do
@@ -43,7 +43,7 @@ describe MicroKanren::Core do
 
   it "who cares" do
     res = take(1, call_fresh(-> (q) { fives.call(q) }).call(empty_state))
-    lprint(res).must_equal '(((([0] . 5)) . 1))'
+    res.to_s.must_equal '(((([0] . 5)) . 1))'
   end
 
   it "take 2 a_and_b stream" do
@@ -52,7 +52,7 @@ describe MicroKanren::Core do
     expected_ast_string =
       "(((([1] . 5) ([0] . 7)) . 2) ((([1] . 6) ([0] . 7)) . 2))"
 
-    lprint(res).must_equal expected_ast_string
+    res.to_s.must_equal expected_ast_string
   end
 
   it "take_all a_and_b stream" do
@@ -61,7 +61,7 @@ describe MicroKanren::Core do
     expected_ast_string =
       "(((([1] . 5) ([0] . 7)) . 2) ((([1] . 6) ([0] . 7)) . 2))"
 
-    lprint(res).must_equal expected_ast_string
+    res.to_s.must_equal expected_ast_string
   end
 
   it "ground appendo" do
@@ -73,21 +73,21 @@ describe MicroKanren::Core do
     expected_ast_string =
       '((([2] b) ([1]) ([0] . a)) . 3)'
 
-    lprint(res).must_equal expected_ast_string
+    res.to_s.must_equal expected_ast_string
   end
 
   it "ground appendo2" do
-    res = lprint(car(ground_appendo2.call(empty_state).call))
+    res = car(ground_appendo2.call(empty_state).call).to_s
     res.must_equal '((([2] b) ([1]) ([0] . a)) . 3)'
   end
 
   it "appendo" do
-    res = lprint(take(2, call_appendo.call(empty_state)))
+    res = take(2, call_appendo.call(empty_state)).to_s
     res.must_equal '(((([0] [1] [2] [3]) ([2] . [3]) ([1])) . 4) ((([0] [1] [2] [3]) ([2] . [6]) ([5]) ([3] [4] . [6]) ([1] [4] . [5])) . 7))'
   end
 
   it "appendo2" do
-    res = lprint(take(2, call_appendo2.call(empty_state)))
+    res = take(2, call_appendo2.call(empty_state)).to_s
     res.must_equal '(((([0] [1] [2] [3]) ([2] . [3]) ([1])) . 4) ((([0] [1] [2] [3]) ([3] [4] . [6]) ([2] . [6]) ([5]) ([1] [4] . [5])) . 7))'
   end
 
@@ -97,16 +97,16 @@ describe MicroKanren::Core do
     # Expected result in scheme:
     # ((() _.0 _.0) ((_.0) _.1 (_.0 . _.1)))
 
-    lprint(res).must_equal '((nil _.0 _.0) ((_.0) _.1 (_.0 . _.1)))'
+    res.to_s.must_equal '((nil _.0 _.0) ((_.0) _.1 (_.0 . _.1)))'
   end
 
   it "reify-1st across appendo2" do
     res = map(method(:reify_1st).to_proc, take(2, call_appendo2.call(empty_state)))
-    lprint(res).must_equal '((nil _.0 _.0) ((_.0) _.1 (_.0 . _.1)))'
+    res.to_s.must_equal '((nil _.0 _.0) ((_.0) _.1 (_.0 . _.1)))'
   end
 
   it "many non-ans" do
     res = take(1, many_non_ans.call(empty_state))
-    lprint(res).must_equal '(((([0] . 3)) . 1))'
+    res.to_s.must_equal '(((([0] . 3)) . 1))'
   end
 end

--- a/spec/micro_kanren/lisp_spec.rb
+++ b/spec/micro_kanren/lisp_spec.rb
@@ -35,7 +35,7 @@ describe MicroKanren::Lisp do
   describe "#map" do
     it "maps a function over a list" do
       func = -> (str) { str.upcase }
-      lprint(map(func, cons("foo", cons("bar", nil)))).must_equal '("FOO" "BAR")'
+      map(func, cons("foo", cons("bar", nil))).to_s.must_equal '("FOO" "BAR")'
     end
   end
 
@@ -79,33 +79,6 @@ describe MicroKanren::Lisp do
 
     it "is false for an empty list" do
       pair?(nil).must_equal false
-    end
-  end
-
-  describe "#lprint" do
-    it "prints an expression correctly" do
-      c = cons(1, cons(2, cons(cons(3, cons(4, nil)), cons(5, nil))))
-      lprint(c).must_equal "(1 2 (3 4) 5)"
-    end
-
-    it "prints a cons cell representation of a simple cell" do
-      lprint(cons('a', 'b')).must_equal '("a" . "b")'
-    end
-
-    it "represents Integers and Floats" do
-      lprint(cons(1, 2)).must_equal '(1 . 2)'
-    end
-
-    it "prints a nested expression" do
-      lprint(cons('a', cons('b', 'c'))).must_equal '("a" "b" . "c")'
-    end
-
-    it "represents Arrays (in scheme, vectors) correctly in printed form" do
-      lprint(cons('a', [])).must_equal '("a" . [])'
-    end
-
-    it "represents nil elements (in scheme, '())" do
-      lprint(cons('a', nil)).must_equal '("a")'
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'minitest/autorun'
 require 'minitest/pride'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
+require 'pry'
 require 'minitest/autorun'
+require 'minitest/pride'
 
 require "mocha"
 


### PR DESCRIPTION
- Moved ::Lisp cons functionality into its own POR class
- Preserved `car` and `cdr` interface in ::Lisp but changing those methods to access attributes on instances of the now-existent Cons class
- Making minitest show prettier specs with `minitest/pride` :)
